### PR TITLE
New tool: Probe center

### DIFF
--- a/QDSpy_GUI_main.ui
+++ b/QDSpy_GUI_main.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
  <widget class="QMainWindow" name="MainWindow">
@@ -1365,6 +1365,177 @@ enabled</string>
         </rect>
        </property>
       </widget>
+     </widget>
+    </widget>
+    <widget class="QWidget" name="tab">
+     <attribute name="title">
+      <string>Probe Center</string>
+     </attribute>
+     <widget class="QGroupBox" name="groupBoxProbeParameters">
+      <property name="geometry">
+       <rect>
+        <x>2</x>
+        <y>8</y>
+        <width>120</width>
+        <height>160</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Parameters</string>
+      </property>
+      <widget class="QLabel" name="probe_width_label">
+       <property name="geometry">
+        <rect>
+         <x>8</x>
+         <y>30</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Width</string>
+       </property>
+      </widget>
+     <widget class="QLabel" name="probe_height_label">
+       <property name="geometry">
+        <rect>
+         <x>8</x>
+         <y>60</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     <widget class="QLabel" name="probe_intensity_label">
+       <property name="geometry">
+        <rect>
+         <x>8</x>
+         <y>90</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Intensity</string>
+       </property>
+      </widget>
+     <widget class="QLabel" name="probe_interval_label">
+       <property name="geometry">
+        <rect>
+         <x>8</x>
+         <y>120</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Interval</string>
+       </property>
+      </widget>
+      <widget class="QSpinBox" name="probe_width">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>30</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>50</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+      </widget>
+     <widget class="QSpinBox" name="probe_height">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>60</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>50</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+      </widget>
+     <widget class="QSpinBox" name="probe_intensity">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>90</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>127</number>
+       </property>
+       <property name="value">
+        <number>127</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+      </widget>
+     <widget class="QDoubleSpinBox" name="probe_interval">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>120</y>
+         <width>50</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>10000</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+       <property name="singleStep">
+        <number>1</number>
+       </property>
+      </widget>
+     </widget>
+     <widget class="QPushButton" name="btnProbeStart">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>100</y>
+        <width>96</width>
+        <height>36</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Start</string>
+      </property>
      </widget>
     </widget>
    </widget>

--- a/QDSpy_core.py
+++ b/QDSpy_core.py
@@ -30,6 +30,7 @@ import QDSpy_core_view as cvw
 import QDSpy_core_support as csp
 import QDSpy_multiprocessing as mpr
 import QDSpy_gamma as gma
+import QDSpy_probeCenter as pce
 import Devices.digital_io as dio
 
 if glo.QDSpy_use_Lightcrafter:
@@ -294,6 +295,26 @@ def main(_fNameStim, _isParentGUI, _Sync=None):
             ssp.Log.write("DEBUG", "mpr.COMPILING, unexpected client data")
                 
           _Sync.setStateSafe(mpr.IDLE)
+          
+        elif _Sync.Request.value == mpr.PROBE_CENTER:
+            
+            if data[0] == mpr.PipeValType.toSrv_probeParam:
+                _Sync.setStateSafe(mpr.PROBE_CENTER)
+                try:
+                    switchGammaLUTByColorMode(_Conf, _View, _Stage, _Stim)    
+                    _Presenter.LCr = connectLCrs(_Conf, _Stim)
+                    setPerformanceHigh(_Conf)
+                    pce.probe_main(data,_Sync)
+                finally:
+                    data = [mpr.PipeValType.toSrv_None]
+                    _Presenter.LCr = disconnectLCrs(_Presenter.LCr)
+                    _Presenter.finish()
+                    setPerformanceNormal(_Conf)
+
+            else:
+                ssp.Log.write("DEBUG", "mpr.PROBE_CENTER, unexpected client data")
+                
+            _Sync.setStateSafe(mpr.IDLE)
 
           
         elif not(_Sync.Request.value in [mpr.CANCELING, mpr.UNDEFINED]):

--- a/QDSpy_multiprocessing.py
+++ b/QDSpy_multiprocessing.py
@@ -19,9 +19,9 @@ from   multiprocessing import Manager, Pipe
 # ---------------------------------------------------------------------
 # Multiprocessing support
 # ---------------------------------------------------------------------     
-UNDEFINED, PRESENTING, COMPILING, CANCELING, TERMINATING, IDLE = (     
+UNDEFINED, PRESENTING, COMPILING, CANCELING, TERMINATING, IDLE, PROBE_CENTER = (     
   "Undefined", "Presenting", "Compiling", "Canceling",  
-  "Terminating", "Idle")
+  "Terminating", "Idle", "Probe center")
   
 class PipeValType:
   toCli_log          = 0
@@ -32,6 +32,7 @@ class PipeValType:
   toSrv_fileName     = 10
   toSrv_changedStage = 11 
   toSrv_changedLEDs  = 12 
+  toSrv_probeParam  = 13
 
 # ---------------------------------------------------------------------
 # Sync class

--- a/QDSpy_probeCenter.py
+++ b/QDSpy_probeCenter.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+QDSpy module - program that generate and display on live the probe center
+
+Copyright (c) 2017 Tom Boissonnet
+All rights reserved.
+"""
+# ---------------------------------------------------------------------
+import QDSpy_stim_support as ssp
+import QDSpy_multiprocessing as mpr
+import pyglet
+import pyglet.gl as GL
+from math import sin, cos,pi
+
+class ProbeCenter():
+    
+    def __init__(self, window, width=50, height=50, intensity=127, interval=1.0, nVertice = 100):
+        self.window = window
+        self.height = height
+        self.width = width
+        self.intensity = intensity
+        self.interval = interval
+        self.nVertice = nVertice
+        self.vertices = self.getEllipseVertices() 
+        self.shiftedVertices = self.vertices
+        self.color = (128+intensity,128+intensity,128+intensity)*nVertice
+        self.highIntensity = True
+
+        pyglet.gl.glClearColor(.5,.5,.5,1)  
+        
+    def invertContrast(self,dt):
+        self.highIntensity = not self.highIntensity
+        if self.highIntensity:
+            self.color = (128+self.intensity,128+self.intensity,128+self.intensity)*self.nVertice
+        else:
+            self.color = (128-self.intensity,128-self.intensity,128-self.intensity)*self.nVertice
+
+    def setShiftedVertices(self,dx, dy):
+        newVertices = ()
+        for i in range(len(self.vertices)):
+            if i%2 == 0:
+                newVertices += (self.vertices[i]+dx,)
+            else:
+                newVertices += (self.vertices[i]+dy,)
+        self.shiftedVertices = newVertices
+    
+    def getEllipseVertices(self):
+        angle = 2*pi/self.nVertice
+        originVertices = ()
+        for i in range(self.nVertice):
+            # Vertices are shifted off the screen to compensate the window's coordinates change
+            # after a presentation of a stimulus.
+            #I do the same changes to be consistent with the rest of the program
+            originVertices += int(self.width/2 * cos(i*angle)- self.window.width/2), int(self.height/2 * sin(i*angle)-self.window.height/2)
+        return originVertices
+
+def probe_main(data,sync):
+    for win in pyglet.app.windows:
+        window = win # need to catch the window in a different way Will work only with the last window...
+
+    probe = ProbeCenter(window,width=data[1],height=data[2],intensity=data[3])
+    firstClick = True # First click is to focus the window, without ending the probe
+    event_loop = pyglet.app.EventLoop()
+       
+    def cleanExit():        
+        event_loop.exit()
+        
+        pyglet.clock.unschedule(checkCancel)
+        pyglet.clock.unschedule(probe.invertContrast)        
+        window.remove_handler("on_mouse_press",on_mouse_press)
+        window.remove_handler("on_draw",on_draw)
+        window.remove_handler("on_mouse_motion", on_mouse_motion)
+        
+        pyglet.gl.glClearColor(0,0,0,1) 
+        window.clear()
+        window.flip()
+        window.clear()
+        window.flip()
+        window.set_mouse_visible(True)    
+    
+    def checkCancel(dt):
+        if sync.Request.value in [mpr.CANCELING, mpr.TERMINATING]:
+            sync.setStateSafe(mpr.CANCELING)
+            cleanExit()
+            
+    @window.event        
+    def on_mouse_press(x, y, button, modifiers):
+        nonlocal firstClick
+        if not firstClick:
+            ssp.Log.write("DATA", "{receptiveFieldCenter: x:"+str(x)+" y:"+str(y)+"}")
+            cleanExit()
+        else:
+            firstClick = False
+     
+    @window.event    
+    def on_mouse_motion(x, y, dx, dy):
+        probe.setShiftedVertices(x,y)
+        
+    @window.event
+    def on_draw():
+        window.clear()
+        pyglet.graphics.draw(probe.nVertice, pyglet.gl.GL_POLYGON, ('v2i', probe.shiftedVertices), ('c3B', probe.color))
+        
+    pyglet.clock.schedule_interval(checkCancel, 0.1)
+    pyglet.clock.schedule_interval(probe.invertContrast, data[4])
+    window.set_mouse_visible(False)
+    
+    #Not exactly sure what i'm doing here with openGl but seems to fix the coordinate
+    # system of the window, because renderer_opengl.py sometimes change it
+    # I took the code from renderer_opengl.py
+    GL.glMatrixMode(GL.GL_PROJECTION)
+    GL.glLoadIdentity()
+    GL.glOrtho(-window.width//2, window.width//2, 
+               -window.height//2, window.height//2, -1, 1)
+    GL.glMatrixMode(GL.GL_MODELVIEW)
+    GL.glLoadIdentity()
+    GL.glPushMatrix()
+    
+    event_loop.run()
+    
+    GL.glPopMatrix()
+    


### PR DESCRIPTION
Added functionnalities to probe the receptive field of neurons.
The probe center is an oval that oscilate between a low and high
intensity grey, and that we move with the mouse to detect were the
recorded neuron respond.
Therefore it need a live display.

Modifications:
**QDSpy_GUI_main_ui
- added the tab and the buttons for the probe_center
**QDSpy_GUI_main.py
- added a function OnClick_btnProbeStart() called when the probe button
is pressed
- copied and adapt runStim() for the probe center
- updated keyPressEvent(), closeEvent() and updateAll() to behave like
runStim with the probe center
**QDSpy_core.py
- copied function associated with the PRESENTATION and adapt it for the
PROBE_CENTER
**QDSpy_multiprocessing:
- Added probe_center to the different enumerations.
**QDSpy_probeCenter:
Contain the probeCenter class and a main function to run the probe
center. Inside it I use openGL functions to try to keep the probe center
located on the mouse pointer (it doesn't work every time...)