### PR TITLE
Bug fix: Logging mixed after cursor moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 Logs
+QDSpy.ini

--- a/QDSpy_GUI_main.py
+++ b/QDSpy_GUI_main.py
@@ -17,7 +17,7 @@ from   ctypes import windll
 from   PyQt5 import uic 
 from   PyQt5.QtWidgets import QMessageBox, QMainWindow, QLabel, QApplication
 from   PyQt5.QtWidgets import QFileDialog, QListWidgetItem, QWidget
-from   PyQt5.QtGui     import QPalette, QColor, QBrush, QTextCharFormat
+from   PyQt5.QtGui     import QPalette, QColor, QBrush, QTextCharFormat, QTextCursor
 from   PyQt5.QtCore    import QRect, QSize
 from   multiprocessing import Process
 import QDSpy_stim as stm
@@ -1048,6 +1048,7 @@ class MainWinClass(QMainWindow, form_class):
       form.setFontPointSize(glo.QDSpy_fontPntSizeHistory)
       
     cursor.setCharFormat(form)
+    cursor.movePosition(QTextCursor.End)
     cursor.insertText(msg)
     self.textBrowserHistory.setTextCursor(cursor)
     self.textBrowserHistory.ensureCursorVisible()


### PR DESCRIPTION
Hi Thomas,
I noticed a bug with the logging. If you select text from the history window, it moves the cursor.
Then subsequent logging will append text in the middle of the history window. And for what I saw it also appears in the saved logs.

In QDSpy_GUI_main.my
<cursor.movePosition(QTextCursor.End)>seems to solve this problem.

Source: https://stackoverflow.com/questions/43805794/how-to-get-qtextbrowser-to-always-insert-text-at-the-end.

In a previous commit, I also added the .ini to the gitignore. This preserves my config when I pull the rep to our setups.

Cheers,
Tom