### PR TITLE
Small features and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
 Logs
 QDSpy.ini
-Stimuli/*.pickle
+*.pickle

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 Logs
 QDSpy.ini
+Stimuli/*.pickle

--- a/QDSpy_core_presenter.py
+++ b/QDSpy_core_presenter.py
@@ -703,6 +703,7 @@ class Presenter:
     ssp.Log.write("DATA", {"stimFileName": self.Stim.fileName, 
                            "stimState": "STARTED",
                            "stimMD5": self.Stim.md5Str}.__str__()) 
+    self.Stage.logData()
     self.View.startRenderingLoop(self)                       
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/QDSpy_stage.py
+++ b/QDSpy_stage.py
@@ -115,10 +115,16 @@ class Stage:
     ssp.Log.write("ok", "Stage info : {0:d},{1:d} pixels, scale: {2:.2f},"
                   "{3:.2f} {4}m/pix, rotation: {5:.0f}{6}, refresh: "
                   "{7} Hz"
-                  .format(int(self.centX_pix), int(self.centY_pix),
+                  .format(int(self.centOffX_pix), int(self.centOffY_pix),
                           self.scalX_umPerPix, self.scalY_umPerPix,
                           u'µ', self.rot_angle, u'°', self.scrReqFreq_Hz))
-
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  def logData(self):
+    ssp.Log.write("DATA", {"scaling_x": self.scalX_umPerPix, 
+                          "scaling_y": self.scalY_umPerPix,
+                          "offset_x": int(self.centOffX_pix),
+                          "offset_y": int(self.centOffY_pix),
+                          "rotation": self.rot_angle}.__str__()) 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   def durToFrames(self, _dur_s):
     if _dur_s > 0.0:

--- a/QDSpy_stim.py
+++ b/QDSpy_stim.py
@@ -1298,7 +1298,8 @@ class Stim:
       
     # Get hash for pickle file  
     #
-    self.md5Str = ssp.getHashStrForFile(sFileName + glo.QDSpy_cPickleFileExt)
+    if not(_onlyInfo):
+      self.md5Str = ssp.getHashStrForFile(sFileName + glo.QDSpy_cPickleFileExt)
 
     # Log some information
     # 

--- a/Shader/StillSquareWaveGrating.cl
+++ b/Shader/StillSquareWaveGrating.cl
@@ -1,0 +1,42 @@
+#version 400
+
+//#QDS ShaderName          =STILL_SQUARE_WAVE_GRATING
+//#QDS ShaderParamNames    =perLen_um; phase_um; minRGB; maxRGB
+//#QDS ShaderParamLengths  =1;1;4;4
+//#QDS ShaderParamDefaults =0.0; 0.0; (0,0,0,255); (255,255,255,255)
+//
+//#QDS ShaderVertexStart
+// ----------------------------------------------------------------------
+void main() 
+{
+  gl_Position    = ftransform();
+}
+// ----------------------------------------------------------------------
+//#QDS ShaderVertexEnd
+
+//#QDS ShaderFragmentStart
+// ----------------------------------------------------------------------
+#define pi    3.141592653589
+#define pi2   6.283185307179
+
+uniform float time_s;
+uniform vec3  obj_xy_rot;
+uniform float perLen_um;
+uniform float phase_um;
+uniform vec4  minRGB;
+uniform vec4  maxRGB;
+
+float         inten;
+vec4          b;
+      
+void main() {
+  vec4  a      = gl_FragCoord;
+  a.x          = a.x -obj_xy_rot.x;
+  a.y          = a.y -obj_xy_rot.y;
+  b.x          = a.x*cos(obj_xy_rot[2]) -a.y*sin(obj_xy_rot[2]);
+  b.y          = a.y*cos(obj_xy_rot[2]) +a.x*sin(obj_xy_rot[2]);
+  inten        = ((ceil(sin((((b.x)+phase_um)/perLen_um) *pi2))+floor(sin((((b.x)+phase_um)/perLen_um) *pi2)))+1)/2;
+  gl_FragColor = mix(minRGB, maxRGB, inten);
+}
+// ----------------------------------------------------------------------
+//#QDS ShaderFragmentEnd


### PR DESCRIPTION
Hi Thomas,
I come today with small few changes:
- I have some pickles that are more than a GB sometimes. When you select it in the GUI, it computes its MD5 hash a first time, and then a second time when you start the stimulus. I'd modified this behaviour so it computes the hash only when starting the stimulus so the GUI is more reactive with large pickles.
- I log the stage offset, scale and rotation so we can use it and record to what location a centred stimulus has been moved. Associated with the ProbeCenter it's very easy to spot a cell and show a stimulus only there.
- I put the *.pickle  in the gitignore. What do you think?
- One more shader to the library. A simple one that generate still gratings. A colleague of mine needs it.

If you want to test the new shader:
```

import QDS
p = {"_sName":"SquareGratings",
     "_sDescr": "Test shader for square gratings"}

QDS.Initialize(p["_sName"],p["_sDescr"])
QDS.DefObj_EllipseEx(1, 200,  200, _enShader=1)
QDS.DefObj_EllipseEx(2, 200,  200, _enShader=1)
QDS.DefObj_EllipseEx(3, 200,  200, _enShader=1)
QDS.DefObj_EllipseEx(4, 200,  200, _enShader=1)
QDS.DefObj_EllipseEx(5, 200,  200, _enShader=1)
QDS.DefObj_EllipseEx(6, 200,  200, _enShader=1)
QDS.DefObj_BoxEx(10, 1280, 720)

for i in range(1,7):
    QDS.DefShader(i, "STILL_SQUARE_WAVE_GRATING")
    QDS.SetShaderParams(i, [100, (i-1)*20, (0,0,0,255),(255,0,0,255)])

QDS.SetObjShader([1,2,3,4,5,6], [1,2,3,4,5,6])
QDS.SetObjColorEx([10], [(128,128,128)])
QDS.LogUserParameters(p)
QDS.StartScript()

for i in range(1,7):
    QDS.Scene_RenderEx(0.5, [10,i] , [(0,0)]*2, [(1,1)]*2, [0]*2,0)
 
QDS.EndScript()
```

Cheers,
Tom