### PR TITLE
Install hid via pip in conda dependencies

### DIFF
--- a/qdspy.yaml
+++ b/qdspy.yaml
@@ -8,3 +8,5 @@ dependencies:
   - conda-forge::moviepy
   - psutil
   - pyserial
+  - pip:
+    - hid


### PR DESCRIPTION
Before this change I got the following error using my conda environment:
```
Traceback (most recent call last):
  File "Stimuli/RGC_Chirp_2.py", line 4, in <module>
    import QDS   
  File "/home/tzenkel/GitRepos/QDSpy/QDS.py", line 26, in <module>
    import QDSpy_stim as stm
  File "/home/tzenkel/GitRepos/QDSpy/QDSpy_stim.py", line 19, in <module>
    import QDSpy_stim_support as ssp
  File "/home/tzenkel/GitRepos/QDSpy/QDSpy_stim_support.py", line 35, in <module>
    import QDSpy_config as cfg
  File "/home/tzenkel/GitRepos/QDSpy/QDSpy_config.py", line 22, in <module>
    import QDSpy_stage as stg
  File "/home/tzenkel/GitRepos/QDSpy/QDSpy_stage.py", line 25, in <module>
    import Devices.lightcrafter as lcr
  File "/home/tzenkel/GitRepos/QDSpy/Devices/lightcrafter.py", line 28, in <module>
    import hid
ModuleNotFoundError: No module named 'hid'
```