### PR TITLE
Linux Compatibility for file path handling and Bugfix when raising StimException

### DIFF
--- a/QDS.py
+++ b/QDS.py
@@ -5,7 +5,7 @@ QDSpy module - stimulus script API
 
 This is a simple Python software for scripting and presenting stimuli
 for visual neuroscience. It is based on QDS, currently uses OpenGL via
-pyglet for graphics. It primarly targets Windows, but may also run on
+pyglet for graphics. It primarily targets Windows, but may also run on
 other operating systems
 
 Copyright (c) 2013-2024 Thomas Euler
@@ -88,7 +88,7 @@ def Initialize(_sName="noname", _sDescr="nodescription", _runMode=1):
     if tLastUpt_pick > tLastUpt_py and not args.compile:
       pythonPath  = os.environ.get("PYTHONPATH", "").split(";")[0]
       if len(pythonPath) > 0:
-        pythonPath += "\\" if PLATFORM_WINDOWS else "/"
+        pythonPath += os.path.sep
       ssp.Log.write("INFO", "Script has not changed, running stimulus now ...")
       s = "python {0}QDSpy_core.py -t={1} {2} {3}"
       os.system(s.format(

--- a/QDSpy_config.py
+++ b/QDSpy_config.py
@@ -46,8 +46,7 @@ class Config:
         #
         self.isWindows = PLATFORM_WINDOWS
         self.pyVersion = sys.version_info[0] + sys.version_info[1] / 10
-        _sep = "\\" if PLATFORM_WINDOWS else "/"
-        self.iniPath = os.getcwd() + _sep + glo.QDSpy_iniFileName
+        self.iniPath = os.getcwd() + os.path.sep + glo.QDSpy_iniFileName
 
         # Set configuration default values
         #

--- a/QDSpy_core_shader.py
+++ b/QDSpy_core_shader.py
@@ -51,7 +51,7 @@ class ShaderManager:
       break
     for fName in f:
       if (os.path.splitext(fName)[1]).lower() == glo.QDSpy_shaderFileExt:
-        self.ShFileList.append(self.Conf.pathShader +"\\" +fName)
+        self.ShFileList.append(os.path.join(self.Conf.pathShader, fName))
     
     # Parse each shader file ...
     #    

--- a/QDSpy_global.py
+++ b/QDSpy_global.py
@@ -9,6 +9,8 @@ All rights reserved.
 2024-06-15 - Fix for breaking change in `configparser`; now using
              `ConfigParser` instead of `RawConfigParser`
 """
+
+import os.path
 # ---------------------------------------------------------------------
 __author__ 	= "code@eulerlab.de"
 
@@ -62,7 +64,7 @@ QDSpy_cPickleProtocol       = 3
 QDSpy_cPickleFileExt        = ".pickle"
 QDSpy_fileVersionID         = 8
 QDSpy_stimFileExt           = ".py"
-QDSpy_pathStimuli           = ".\\Stimuli\\"
+QDSpy_pathStimuli           = "." + os.path.sep + "Stimuli" + os.path.sep
 QDSpy_autorunStimFileName   = "__autorun"
 QDSpy_autorunDefFileName    = "__autorun_default_DO_NOT_DELETE"
 
@@ -77,14 +79,14 @@ QDSpy_movAllowedMovieExts   = [".png", ".jpg"]
 
 QDSpy_vidAllowedVideoExts   = [".avi"]
 
-QDSpy_pathApplication       = ".\\"
+QDSpy_pathApplication       = "." + os.path.sep
 QDSpy_iniFileName           = "QDSpy.ini"
 
-QDSpy_pathLogFiles          = ".\\Logs\\"
+QDSpy_pathLogFiles          = "." + os.path.sep + "Logs" + os.path.sep
 QDSpy_logFileExtension      = ".log"
 QDSpy_doLogTimeStamps       = True
 
-QDSpy_pathShader            = ".\\Shader\\"
+QDSpy_pathShader            = "." + os.path.sep + "Shader" + os.path.sep
 QDSpy_shaderFileExt         = ".cl"
 QDSpy_shaderFileCmdTok      = "#qds"
 QDSpy_loadShadersOnce       = True

--- a/QDSpy_stim.py
+++ b/QDSpy_stim.py
@@ -541,7 +541,7 @@ class Stim:
             VdOb = self.VidList[iVdOb]
         except KeyError:
             self.LastErrC = StimErrC.noMatchingID
-            raise StimException
+            raise StimException(self.LastErrC)
 
         d = dict()
         d["dxFr"] = VdOb[SV_field_dxFr]
@@ -570,14 +570,14 @@ class Stim:
             or (len(_IDs) != len(_newAlphas))
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         for ID in _IDs:
             try:
                 self.ObjDict[ID]
             except KeyError:
                 self.LastErrC = StimErrC.noMatchingID
-                raise StimException
+                raise StimException(self.LastErrC)
 
         RGBEx = ssp.completeRGBList(_newRGBs)
         newSce = [
@@ -607,14 +607,14 @@ class Stim:
             or (len(_IDs) != len(_newRGBAs))
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         for ID in _IDs:
             try:
                 self.ObjDict[ID]
             except KeyError:
                 self.LastErrC = StimErrC.noMatchingID
-                raise StimException
+                raise StimException(self.LastErrC)
 
         RGBAEx = ssp.completeRGBAList(_newRGBAs)
         newSce = [
@@ -643,7 +643,7 @@ class Stim:
             or len(_rgb) not in [3, 6]
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
     # *********************
     # *********************
@@ -660,13 +660,13 @@ class Stim:
         """
         if not (isinstance(_shID, int)) or not (isinstance(_shParams, list)):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         try:
             iSh = self.ShDict[_shID]
         except KeyError:
             self.LastErrC = StimErrC.noMatchingID
-            raise StimException
+            raise StimException(self.LastErrC)
 
         shP = _shParams
         shType = self.ShList[iSh][SH_field_shaderType]
@@ -675,7 +675,7 @@ class Stim:
             ShD = self.ShManager.ShDesc[iShD]
         except ValueError:
             self.LastErrC = StimErrC.invalidShaderType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         # Convert RBG values for each shader parameter (uniform) that
         # contains the substring "rgb"
@@ -695,17 +695,17 @@ class Stim:
         """
         if not (isinstance(_IDs, list)) or not (isinstance(_shIDs, list)):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         for ID in _IDs:
             try:
                 # self.ObjDict[ID]
                 if self.ObjList[self.ObjDict[ID]][SO_field_useShader] == 0:
                     self.LastErrC = StimErrC.notShaderObject
-                    raise StimException
+                    raise StimException(self.LastErrC)
             except KeyError:
                 self.LastErrC = StimErrC.noMatchingID
-                raise StimException
+                raise StimException(self.LastErrC)
 
         for ID in _shIDs:
             if ID < 0:
@@ -714,7 +714,7 @@ class Stim:
                 self.ShDict[ID]
             except KeyError:
                 self.LastErrC = StimErrC.noMatchingID
-                raise StimException
+                raise StimException(self.LastErrC)
 
         newSce = [StimSceType.changeObjShader, -1, self.nSce, False, _IDs, _shIDs]
         self.SceList.append(newSce)
@@ -731,7 +731,7 @@ class Stim:
         """
         if not (isinstance(_newRGB, tuple)):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         RGBEx = ssp.completeRGBList([_newRGB])
         newSce = [StimSceType.changeBkgCol, -1, self.nSce, False, RGBEx[0]]
@@ -762,7 +762,7 @@ class Stim:
         """
         if not (isinstance(_dict, dict)):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         # **************************************
         # **************************************
@@ -788,7 +788,7 @@ class Stim:
         """
         if _dur_s < 0:
             self.LastErrC = StimErrC.invalidDuration
-            raise StimException
+            raise StimException(self.LastErrC)
         elif _dur_s == 0:
             dur = -1
         else:
@@ -860,7 +860,7 @@ class Stim:
 
         if res[0] != lcr.ERROR.OK:
             self.LastErrC = StimErrC.DeviceError_LCr
-            raise StimException
+            raise StimException(self.LastErrC)
 
         newSce = [StimSceType.sendCommandToLCr, -1, self.nSce, False, [_cmd] + _p]
         self.SceList.append(newSce)
@@ -896,18 +896,18 @@ class Stim:
             or (len(_IDs) != len(_rot))
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         if _dur_s <= 0:
             self.LastErrC = StimErrC.invalidDuration
-            raise StimException
+            raise StimException(self.LastErrC)
 
         for ID in _IDs:
             try:
                 self.ObjDict[ID]
             except KeyError:
                 self.LastErrC = StimErrC.noMatchingID
-                raise StimException
+                raise StimException(self.LastErrC)
 
         newSce = [
             StimSceType.renderSce,
@@ -939,7 +939,7 @@ class Stim:
             or (_screen >= glo.QDSpy_maxNumberOfScreens)
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         try:
             iMvOb = self.MovDict[_ID]
@@ -948,12 +948,12 @@ class Stim:
             # raise(StimException(self.LastErrC))
         except KeyError:
             self.LastErrC = StimErrC.noMatchingID
-            raise StimException
+            raise StimException(self.LastErrC)
 
         tmpMCtr = mov.MovieCtrl(_seq, _ID, _nFr=self.MovList[iMvOb][SM_field_nFr])
         if not (tmpMCtr.check()):
             self.LastErrC = StimErrC.invalidMovieSeq
-            raise StimException
+            raise StimException(self.LastErrC)
 
         newSce = [
             StimSceType.startMovie,
@@ -985,13 +985,13 @@ class Stim:
             or _screen not in [0, 1]
         ):
             self.LastErrC = StimErrC.invalidParamType
-            raise StimException
+            raise StimException(self.LastErrC)
 
         try:
             _ = self.VidDict[_ID]
         except KeyError:
             self.LastErrC = StimErrC.noMatchingID
-            raise StimException
+            raise StimException(self.LastErrC)
 
         newSce = [
             StimSceType.startVideo,
@@ -1021,7 +1021,7 @@ class Stim:
             and (len(self.VidList) == 0)
         ) or (len(self.SceList) == 0):
             self.LastErrC = StimErrC.nothingToCompile
-            raise StimException
+            raise StimException(self.LastErrC)
 
         # Clear compiled scene data
         # First, lists corresponding to SceList, then lists with entries

--- a/QDSpy_stim_movie.py
+++ b/QDSpy_stim_movie.py
@@ -151,9 +151,7 @@ class Movie:
         """
         tempStr = (os.path.splitext(os.path.basename(_fName)))[0]
         tempDir = os.path.dirname(_fName)
-        if len(tempDir) > 0:
-            tempDir += "\\"
-        self.fNameDesc = tempDir + tempStr + glo.QDSpy_movDescFileExt
+        self.fNameDesc = os.path.join(tempDir, tempStr + glo.QDSpy_movDescFileExt)
         self.fNameImg = _fName
         self.fExtImg = os.path.splitext(_fName)[1].lower()
         self.isTestOnly = _testOnly

--- a/QDSpy_stim_video.py
+++ b/QDSpy_stim_video.py
@@ -86,9 +86,6 @@ class Video:
     """ Reads a movie file (e.g. AVI); a description file is not needed
         Returns an error of the QDSpy_stim.StimErrC class
     """   
-    tempDir = os.path.dirname(_fName)
-    if len(tempDir) > 0:
-      tempDir += "\\"
     self.fNameVideo = _fName
     self.fExtVideo  = os.path.splitext(_fName)[1].lower()
     self.isTestOnly = _testOnly

--- a/Stimuli/New Stimuli/RGC_BWNoise_3.py
+++ b/Stimuli/New Stimuli/RGC_BWNoise_3.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------------------
 import collections
 from functools import partial
+import os.path
 import QDS
 
 # Define global stimulus parameters
@@ -23,7 +24,7 @@ def buildStimulus(p):
     
     '''Read file with M sequence'''
     try:
-      f         = open(p['fPath'] +'\\' +p['fNameNoise'] +'.txt', 'r')
+      f         = open(p['fPath'] + os.path.sep +p['fNameNoise'] +'.txt', 'r')
       iLn       = 0 
       p['Frames']    = []
         


### PR DESCRIPTION
The separator token between folders is different between windows (`\\`) and linux (`/`). The separator used by the system can be accessed in python with `os.path.sep`. I changed all occurences of `\\` with `os.path.sep` to make the filepath handling also work on Linux.

Additionally, I found that the StimException as it excepts a single parameter, but none was provided. This lead  to below error. I fixed this by passing the error code its constructor.
Error message before this PR:
```
Traceback (most recent call last):
  File "/home/tzenkel/GitRepos/QDSpy/Stimuli/moving_gratingsV4_4.py", line 58, in <module>
    QDS.Start_Movie(1, (0,0), [_iG, _iG+ p["nPhaseFr"]-1, 1, 1], p["scalingF"], 255, 0)
  File "/home/tzenkel/GitRepos/QDSpy/QDS.py", line 846, in Start_Movie
    _Stim.startMovie(_iobj, _opos, _seq, _omag, _trans, _oang, _screen)
  File "/home/tzenkel/GitRepos/QDSpy/QDSpy_stim.py", line 951, in startMovie
    raise StimException
TypeError: StimException.__init__() missing 1 required positional argument: 'value'
```