### PR TITLE
Use os.path.join for file path handling

### DIFF
--- a/QDS.py
+++ b/QDS.py
@@ -24,7 +24,6 @@ import sys
 import platform
 from   datetime import datetime
 import QDSpy_checks  # noqa: F401
-import QDSpy_file_support as fsu
 import QDSpy_global as glo
 import QDSpy_stim as stm
 import QDSpy_config as cfg
@@ -87,17 +86,12 @@ def Initialize(_sName="noname", _sDescr="nodescription", _runMode=1):
     if os.path.isfile(fNameDir_pk):
       tLastUpt_pick = datetime.fromtimestamp(os.path.getmtime(fNameDir_pk))
       if tLastUpt_pick > tLastUpt_py and not args.compile:
-        pythonPath = fsu.getQDSpyPath()
-        if len(pythonPath) > 0:
-          pythonPath += "\\" if PLATFORM_WINDOWS else "/"
-        
         _log.Log.write("INFO", "Script has not changed, running stimulus now ...")
-        s = "python {0}QDSpy_core.py -t={1} {2} {3}"
-        os.system(s.format(
-            pythonPath if PLATFORM_WINDOWS else "",
-            args.timing, "-v" if args.verbose else "",
-            _Stim.fNameDir)
-          )
+        command = "python {0} -t={1} {2} {3}".format(
+          os.path.join(glo.QDSpy_path, "QDSpy_core.py"),
+          args.timing, "-v" if args.verbose else "",
+          _Stim.fNameDir)
+        os.system(command)
         '''
         os.system(s.format(
             pythonPath if PLATFORM_WINDOWS else "",

--- a/QDSpy_MQTT_main.py
+++ b/QDSpy_MQTT_main.py
@@ -18,7 +18,6 @@ import os
 from collections import deque
 import QDSpy_global as glo
 import QDSpy_stim as stm
-import QDSpy_file_support as fsu
 from QDSpy_app import QDSpyApp, State, StateStr
 import Libraries.mqtt_client as mqtt
 import Libraries.mqtt_globals as mgl
@@ -115,7 +114,7 @@ class AppMQTT(QDSpyApp):
             if self.state in [State.idle, State.ready]:  
                 # Try loading the stimulus
                 # "load,<msg index>,<stimulus file name>"
-                fName = fsu.getQDSpyPath() +self.Conf.pathStim +msg[1][1]
+                fName = os.path.join(self.Conf.pathStim, msg[1][1])
                 errC = self.loadStim(fName)
 
         elif msg[0] == mgl.Command.PLAY:

--- a/QDSpy_app.py
+++ b/QDSpy_app.py
@@ -413,7 +413,6 @@ class QDSpyApp(object):
     def openLogFile(_fPath) -> TextIO:
         """Open a log file
         """
-        _fPath = fsu.repairPath(fsu.getQDSpyPath() +_fPath)
         #print("openLogFile", _fPath)
         os.makedirs(_fPath, exist_ok=True)
         fName = time.strftime("%Y%m%d_%H%M%S")

--- a/QDSpy_config.py
+++ b/QDSpy_config.py
@@ -48,8 +48,7 @@ class Config:
         #
         self.isWindows = PLATFORM_WINDOWS
         self.pyVersion = sys.version_info[0] + sys.version_info[1] / 10
-        _sep = "\\" if PLATFORM_WINDOWS else "/"
-        self.iniPath = os.getcwd() + _sep + glo.QDSpy_iniFileName
+        self.iniPath = glo.QDSpy_iniFileName
 
         # Set configuration default values
         #

--- a/QDSpy_core_presenter.py
+++ b/QDSpy_core_presenter.py
@@ -29,7 +29,6 @@ import QDSpy_stim_movie as mov
 import QDSpy_stim_video as vid
 import QDSpy_stim_draw as drw
 import QDSpy_core_support as csp
-import QDSpy_file_support as fsu
 import QDSpy_core_shader as csh
 from Libraries.log_helper import Log
 import Libraries.multiprocess_helper as mpr
@@ -68,8 +67,7 @@ class Presenter:
         self.Conf = _Conf
         self.View = _View
         self.LCr = _LCr
-        self.pathQDSpy = fsu.getQDSpyPath()
-        self.ShManager = csh.ShaderManager(self.Conf, self.pathQDSpy)
+        self.ShManager = csh.ShaderManager(self.Conf)
         self.useSound = glo.QDSpy_isUseSound
         self.reset()
         
@@ -84,11 +82,10 @@ class Presenter:
         if self.useSound:
             Log.write("DEBUG", "Loading sounds ...")
             self.SoundPlayer = SoundPlayer()    
-            p = self.pathQDSpy +glo.QDSpy_pathSounds
-            self.SoundPlayer.add(Sounds.OK, p +glo.QDSpy_soundOk)
-            self.SoundPlayer.add(Sounds.ERROR, p +glo.QDSpy_soundError)
-            self.SoundPlayer.add(Sounds.STIM_START, p +glo.QDSpy_soundStimStart)
-            self.SoundPlayer.add(Sounds.STIM_END, p +glo.QDSpy_soundStimEnd)
+            self.SoundPlayer.add(Sounds.OK, os.path.join(glo.QDSpy_pathSounds, glo.QDSpy_soundOk))
+            self.SoundPlayer.add(Sounds.ERROR, os.path.join(glo.QDSpy_pathSounds, glo.QDSpy_soundError))
+            self.SoundPlayer.add(Sounds.STIM_START, os.path.join(glo.QDSpy_pathSounds, glo.QDSpy_soundStimStart))
+            self.SoundPlayer.add(Sounds.STIM_END, os.path.join(glo.QDSpy_pathSounds, glo.QDSpy_soundStimEnd))
             Log.write("DEBUG", "... done")
         else:
             self.SoundPlayer = None    

--- a/QDSpy_core_shader.py
+++ b/QDSpy_core_shader.py
@@ -17,7 +17,6 @@ __author__ = "code@eulerlab.de"
 
 import os
 import QDSpy_global as glo
-import QDSpy_file_support as fsu
 import Libraries.log_helper as _log
 from Graphics.shader_opengl import Shader
 
@@ -37,7 +36,7 @@ class ShaderFileCmd:
 # Shader manager class
 # ---------------------------------------------------------------------
 class ShaderManager:
-    def __init__(self, _Conf, _path: str):
+    def __init__(self, _Conf):
         # Initializing
         self.Conf = _Conf
         self.ShFileList = []
@@ -45,16 +44,15 @@ class ShaderManager:
         self.ShTypes = []
         self.ShVertCode = []
         self.ShFragCode = []
-        pshader = fsu.repairPath(_path +self.Conf.pathShader)
 
         # Make a list of the available shader files ...
         f = []
-        for dirpath, dirnames, filenames in os.walk(pshader):
+        for dirpath, dirnames, filenames in os.walk(self.Conf.pathShader):
             f.extend(filenames)
             break
         for fName in f:
             if (os.path.splitext(fName)[1]).lower() == glo.QDSpy_shaderFileExt:
-                self.ShFileList.append(pshader + fName)
+                self.ShFileList.append(self.Conf.pathShader + fName)
 
         # Parse each shader file ...
         isInVert = False

--- a/QDSpy_file_support.py
+++ b/QDSpy_file_support.py
@@ -51,12 +51,12 @@ def getFNameNoExt(_fName):
 def getStimCompileState(_fName: str) -> bool:
     """ Check if pickle-file is current
     """
-    fPath = os.path.splitext(repairPath(_fName))[0]
+    dirPath = os.path.splitext(_fName)[0]
     #print("getStimCompileState2", _fName, fPath)
     try:
-        tStamp = os.path.getmtime(fPath + glo.QDSpy_stimFileExt)
+        tStamp = os.path.getmtime(os.path.join(dirPath, glo.QDSpy_stimFileExt))
         tPy = datetime.fromtimestamp(tStamp)
-        tStamp = os.path.getmtime(fPath + glo.QDSpy_cPickleFileExt)
+        tStamp = os.path.getmtime(os.path.join(dirPath, glo.QDSpy_cPickleFileExt))
         tPck = datetime.fromtimestamp(tStamp)
         return tPck > tPy
     
@@ -69,7 +69,7 @@ def getStimCompileState(_fName: str) -> bool:
 def getStimExists(_fName):
     """ Check if stimulus file (.py) exists
     """
-    fPath = repairPath(_fName) + glo.QDSpy_stimFileExt
+    fPath = _fName + glo.QDSpy_stimFileExt
     #print("getStimExists", fPath, os.path.isfile(fPath))
     return os.path.isfile(fPath)
 

--- a/QDSpy_global.py
+++ b/QDSpy_global.py
@@ -9,11 +9,14 @@ All rights reserved.
 2024-06-15 - Fix for breaking change in `configparser`; now using
              `ConfigParser` instead of `RawConfigParser`
 """
+import os.path
+
 # ---------------------------------------------------------------------
 __author__ 	= "code@eulerlab.de"
 
 # fmt: off
 # ---------------------------------------------------------------------
+QDSpy_path                  = os.path.dirname(__file__)
 QDSpy_versionStr            = "QDSpy v0.92 beta"
 QDSpy_copyrightStr          = "(c) 2013-24 Thomas Euler"
 QDSpy_appID                 = u"QDSpy3.v090beta.thomas_euler.eulerlab.de"
@@ -26,7 +29,7 @@ QDSpy_noStimArg             = False
 QDSpy_loop_sleep_s          = 0.01
 
 QDSpy_isUseSound            = False
-QDSpy_pathSounds            = ".\\Sounds\\"
+QDSpy_pathSounds            = os.path.join(QDSpy_path, "Sounds") + os.path.sep
 QDSpy_soundStimStart        = "stim_start.mp3"
 QDSpy_soundStimEnd          = "stim_end.mp3"
 QDSpy_soundError            = "error.mp3" 
@@ -72,7 +75,7 @@ QDSpy_cPickleProtocol       = 3
 QDSpy_cPickleFileExt        = ".pickle"
 QDSpy_fileVersionID         = 8
 QDSpy_stimFileExt           = ".py"
-QDSpy_pathStimuli           = ".\\Stimuli\\"
+QDSpy_pathStimuli           = os.path.join(QDSpy_path, "Stimuli") + os.path.sep
 QDSpy_autorunStimFileName   = "__autorun"
 QDSpy_autorunDefFileName    = "__autorun_default_DO_NOT_DELETE"
 
@@ -90,7 +93,7 @@ QDSpy_vidAllowedVideoExts   = [".avi"]
 QDSpy_pathApplication       = ".\\"
 QDSpy_iniFileName           = "QDSpy.ini"
 
-QDSpy_pathLogFiles          = ".\\Logs\\"
+QDSpy_pathLogFiles          = os.path.join(QDSpy_path, "Logs") + os.path.sep
 QDSpy_logFileExtension      = ".log"
 QDSpy_doLogTimeStamps       = True
 

--- a/QDSpy_global.py
+++ b/QDSpy_global.py
@@ -90,8 +90,8 @@ QDSpy_movAllowedMovieExts   = [".png", ".jpg"]
 
 QDSpy_vidAllowedVideoExts   = [".avi"]
 
-QDSpy_pathApplication       = ".\\"
-QDSpy_iniFileName           = "QDSpy.ini"
+QDSpy_pathApplication       = QDSpy_path
+QDSpy_iniFileName           = os.path.join(QDSpy_path, "QDSpy.ini")
 
 QDSpy_pathLogFiles          = os.path.join(QDSpy_path, "Logs") + os.path.sep
 QDSpy_logFileExtension      = ".log"

--- a/QDSpy_stim.py
+++ b/QDSpy_stim.py
@@ -452,8 +452,7 @@ class Stim:
         shader type exists
         """
         if self.ShManager is None:
-            _path = fsp.getQDSpyPath()
-            self.ShManager = csh.ShaderManager(self.Conf, _path)
+            self.ShManager = csh.ShaderManager(self.Conf)
         if _shType not in self.ShManager.getShaderTypes():
             self.LastErrC = StimErrC.invalidShaderType
             raise StimException(StimErrC.invalidShaderType)
@@ -1381,13 +1380,13 @@ class Stim:
         if not (_onlyInfo):
             _log.Log.write(" ", "Loading compiled stimulus...", True)
 
-        sPath = fsp.repairPath(_sFileName)
+        sPath = _sFileName
         try:
-            with open(sPath + glo.QDSpy_cPickleFileExt, "rb") as stimFile:
+            with open(_sFileName + glo.QDSpy_cPickleFileExt, "rb") as stimFile:
                 '''
                 self.fileName = sFileName.replace("\\\\", "\\")
                 '''
-                self.fileName = sPath 
+                self.fileName = sPath
                 #print("load", sPath)
                 stimPick = pickle.Unpickler(stimFile)
                 ID = stimPick.load()

--- a/QDSpy_stim_movie.py
+++ b/QDSpy_stim_movie.py
@@ -21,15 +21,11 @@ All rights reserved.
 __author__ = "code@eulerlab.de"
 
 import os.path
-import platform
 import configparser
 import QDSpy_stim as stm
 import QDSpy_global as glo
-import QDSpy_file_support as fsu
 import Libraries.log_helper as _log
 import Graphics.renderer_opengl as rdr
-
-PLATFORM_WINDOWS = platform.system() == "Windows"
 
 # ---------------------------------------------------------------------
 # Movie object class
@@ -159,17 +155,9 @@ class Movie:
         tempStr = (os.path.splitext(os.path.basename(_fName)))[0]
         self.fExtImg = os.path.splitext(_fName)[1].lower()
         self.isTestOnly = _testOnly
-
-        if PLATFORM_WINDOWS:
-            tempDir = os.path.dirname(_fName)
-            if len(tempDir) > 0:
-                tempDir += "\\"
-            self.fNameDesc = tempDir + tempStr + glo.QDSpy_movDescFileExt
-            self.fNameImg = _fName
-        else:
-            tempDir = os.getcwd()
-            self.fNameDesc = fsu.repairPath(tempDir + tempStr) + glo.QDSpy_movDescFileExt
-            self.fNameImg = fsu.repairPath(tempDir + tempStr) + self.fExtImg
+        tempDir = os.path.dirname(_fName)
+        self.fNameDesc = os.path.join(tempDir, tempStr) + glo.QDSpy_movDescFileExt
+        self.fNameImg = _fName
 
         if self.fExtImg in glo.QDSpy_movAllowedMovieExts:
             return self.__loadMontage()

--- a/QDSpy_stim_video.py
+++ b/QDSpy_stim_video.py
@@ -22,7 +22,6 @@ import os
 import platform
 import QDSpy_stim as stm
 import QDSpy_global as glo
-import QDSpy_file_support as fsu
 import Libraries.log_helper as _log
 import moviepy.editor as mpe
 import Graphics.renderer_opengl as rdr
@@ -83,18 +82,9 @@ class Video:
         """Reads a movie file (e.g. AVI); a description file is not needed
         Returns an error of the QDSpy_stim.StimErrC class
         """
-        tempStr = (os.path.splitext(os.path.basename(_fName)))[0]
         self.fExtVideo = os.path.splitext(_fName)[1].lower()
         self.isTestOnly = _testOnly
-
-        if PLATFORM_WINDOWS:
-            tempDir = os.path.dirname(_fName)
-            if len(tempDir) > 0:
-                tempDir += "\\"
-            self.fNameVideo = _fName
-        else:
-            tempDir = os.getcwd()
-            self.fNameVideo = fsu.repairPath(tempDir + tempStr) + self.fExtVideo
+        self.fNameVideo = _fName
 
         if self.fExtVideo in glo.QDSpy_vidAllowedVideoExts:
             return self.__loadVideo()


### PR DESCRIPTION
(This is potentially shooting over the top as I changed more lines than I expected)


This PR simplifies the code by specifying the initial file paths directly as absolute paths and by consistently using os.path.join:
- In `QDSpy_global` get the path to the QDSpy directory and set all following paths relative to that (e.g. using os.path.join(QDSpy_path, "Sounds")). This also gets rid of path concatenations and does not rely on fixing the paths later when running on Linux.
- Use os.path.join for all subsequent path concatenation to stay platform independant.

This behavior changes the way people have to use the config in case they want to overwrite the defaults. They now have to specify absolute paths (potential downside), but these paths do not have to point to the same directory where QDSpy is (downside). If this is too big of a change I can either:
- Change the PR to only fix the initial issue stated below
- Put additional logic in QDSpy_config to expand the paths provided in the config if the directory they are pointing to does not exist



### Initial issue
The following code changes the path that included the Stimulus directory (e.g. `./Stimulus/foo...`) to point to the current directory if you are running on Linux. For me that was a problem, as the file path was off then and it did not load the file (similar for QDSpy_stim_video). This should be fixed with the changes above and worked on my Linux computer.
https://github.com/eulerlab/QDSpy/blob/1505933b7a4a9e336801bd30ca9025e9b8f85e21/QDSpy_stim_movie.py#L169-L172
