### PR TITLE
Fix for executing python command with spaces in filepath

### DIFF
--- a/QDS.py
+++ b/QDS.py
@@ -89,11 +89,12 @@ def Initialize(_sName="noname", _sDescr="nodescription", _runMode=1):
       if tLastUpt_pk > tLastUpt_py and not args.compile:
         # Stimulus unchanged, therefore run directly
         _log.Log.write("INFO", "Script has not changed, running stimulus now ...")
-        command = "python {0} -t={1} {2} {3}".format(
+        command = 'python "{0}" -t={1} {2} "{3}"'.format(
           fsu.getJoinedPath(glo.QDSpy_path, "QDSpy_core.py"),
           args.timing, "-v" if args.verbose else "",
           _Stim.fNameDir
         )
+        _log.Log.write("INFO", "Executing the following command: {0}".format(command))
         os.system(command)
         exit()
 

--- a/QDSpy_core_shader.py
+++ b/QDSpy_core_shader.py
@@ -57,7 +57,7 @@ class ShaderManager:
             break
         for fName in f:
             if (os.path.splitext(fName)[1]).lower() == glo.QDSpy_shaderFileExt:
-                self.ShFileList.append(pshader + fName)
+                self.ShFileList.append(fsu.getJoinedPath(pshader, fName))
 
         # Parse each shader file ...
         isInVert = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyqt6
 numpy
 pywin32
 pyglet==1.5.5
-moviepy
+moviepy<2
 psutil
 pyserial
 hidapi


### PR DESCRIPTION
On Dominic's Laptop his home folder had a space in it ("...\dominic lastname/..."). This lead to problems when executing the python command.
Putting the file paths into quotation marks fixed this.

We also noticed that moviepy got upgraded in November 2024 to version 2 (see its [releases](https://github.com/Zulko/moviepy/releases/tag/v2.0.0). When installing moviepy 2 it fails with:
```
Traceback (most recent call last):
  File "/home/tzenkel/GitRepos/QDS py/Stimuli/RGC_Chirp_2.py", line 4, in <module>
    import QDS   
  File "/home/tzenkel/GitRepos/QDS py/QDS.py", line 29, in <module>
    import QDSpy_stim as stm
  File "/home/tzenkel/GitRepos/QDS py/QDSpy_stim.py", line 28, in <module>
    import QDSpy_stim_video as vid
  File "/home/tzenkel/GitRepos/QDS py/QDSpy_stim_video.py", line 27, in <module>
    import moviepy.editor as mpe
ModuleNotFoundError: No module named 'moviepy.editor
```
To avoid this, I added `moviepy<2` to make sure we stick to using moviepy version 1 which works perfectly well with QDSpy. 

## To reproduce the error
I could reproduce this on my computer when renaming the `QDSpy` folder to `QDS py` (note the space). Then it tries to execute the command:
```
python /home/tzenkel/GitRepos/QDS py/QDSpy_core.py -t=0  Stimuli/RGC_Chirp_2
```
And fails with:
```
python: can't open file '/home/tzenkel/GitRepos/QDS': [Errno 2] No such file or directory
```
