### PR TITLE
fixed array preallocation shape bug

### DIFF
--- a/QDSpy_stim_video.py
+++ b/QDSpy_stim_video.py
@@ -89,7 +89,7 @@ class Video:
             self._reiterate()
         else:
             self.frames = np.zeros(
-                (self.nFr, self.dxFr, self.dyFr, 3), dtype=np.uint8
+                (self.nFr, self.dyFr, self.dxFr, 3), dtype=np.uint8
             )
             tmp = self.video.iter_frames()
             for iFr in range(self.nFr):


### PR DESCRIPTION
When trying to play non square AVIs I ran into the following error: 

`File "C:\Users\samuel\GitRepos\euler_lab\QDSpy\QDSpy_stim_video.py", line 96, in __loadVideo
    self.frames[iFr] = next(tmp)
    ~~~~~~~~~~~^^^^^
ValueError: could not broadcast input array from shape (96,128,3) into shape (128,96,3)`

This is because `self.frames` has shape `(self.nFr, self.dxFr, self.dyFr, 3)`. However, self.video is an instance of MoviePy's `VideoFileClip`, that inherits from MoviePy's `Clip`, which in its `iter_frames()` method returns each frame of the clip as a HxWxN Numpy array (see documentation here: https://zulko.github.io/moviepy/reference/reference/moviepy.Clip.Clip.html#moviepy.Clip.Clip). I therefore changed the shape of `self.frames` to `(self.nFr, self.dyFr, self.dxFr, 3)`. This allowed me to play non square AVIs without problems.
